### PR TITLE
feat: Implement dynamic version injection from Git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
       run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     
     - name: Build for all platforms
-      run: make build-all
+      run: make build-all VERSION=${{ steps.version.outputs.VERSION }}
     
     - name: Create release archives
-      run: make release
+      run: make release VERSION=${{ steps.version.outputs.VERSION }}
     
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 # Variables
 BINARY_NAME=passgen
-VERSION=1.0.0
+# Dynamic versioning based on git tags
+VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_DIR=build
 DIST_DIR=dist
 
@@ -24,14 +25,14 @@ all: clean test build
 # Build the binary
 .PHONY: build
 build:
-	@echo "Building $(BINARY_NAME)..."
+	@echo "Building $(BINARY_NAME) version $(VERSION)..."
 	@mkdir -p $(BUILD_DIR)
 	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) .
 
 # Build for multiple platforms
 .PHONY: build-all
 build-all: clean
-	@echo "Building for multiple platforms..."
+	@echo "Building $(BINARY_NAME) version $(VERSION) for multiple platforms..."
 	@mkdir -p $(DIST_DIR)
 	
 	# Linux AMD64
@@ -49,7 +50,7 @@ build-all: clean
 	# Windows AMD64
 	GOOS=windows GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-windows-amd64.exe .
 	
-	@echo "Cross-compilation complete!"
+	@echo "Cross-compilation complete for version $(VERSION)!"
 
 # Run tests
 .PHONY: test
@@ -75,13 +76,13 @@ deps:
 # Install the binary to GOPATH/bin
 .PHONY: install
 install: build
-	@echo "Installing $(BINARY_NAME)..."
+	@echo "Installing $(BINARY_NAME) version $(VERSION)..."
 	@cp $(BUILD_DIR)/$(BINARY_NAME) $(GOPATH)/bin/
 
 # Run the application
 .PHONY: run
 run: build
-	@echo "Running $(BINARY_NAME)..."
+	@echo "Running $(BINARY_NAME) version $(VERSION)..."
 	@./$(BUILD_DIR)/$(BINARY_NAME)
 
 # Format code
@@ -103,7 +104,7 @@ lint:
 # Create release archives
 .PHONY: release
 release: build-all
-	@echo "Creating release archives..."
+	@echo "Creating release archives for version $(VERSION)..."
 	@mkdir -p $(DIST_DIR)/releases
 	
 	# Create tar.gz for Unix systems
@@ -115,12 +116,17 @@ release: build-all
 	# Create zip for Windows
 	@cd $(DIST_DIR) && zip releases/$(BINARY_NAME)-$(VERSION)-windows-amd64.zip $(BINARY_NAME)-windows-amd64.exe
 	
-	@echo "Release archives created in $(DIST_DIR)/releases/"
+	@echo "Release archives created in $(DIST_DIR)/releases/ for version $(VERSION)"
 
 # Development workflow
 .PHONY: dev
 dev: deps fmt lint test build
-	@echo "Development build complete!"
+	@echo "Development build complete for version $(VERSION)!"
+
+# Show version
+.PHONY: version
+version:
+	@echo "Current version: $(VERSION)"
 
 # Help
 .PHONY: help
@@ -138,4 +144,5 @@ help:
 	@echo "  lint       - Lint code"
 	@echo "  release    - Create release archives"
 	@echo "  dev        - Full development workflow"
+	@echo "  version    - Show current version"
 	@echo "  help       - Show this help message" 

--- a/main.go
+++ b/main.go
@@ -17,8 +17,10 @@ const (
 	Uppercase     = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	Numbers       = "0123456789"
 	Symbols       = "!@#$%^&*()_+-=[]{}|;:,.<>?"
-	Version       = "1.0.0"
 )
+
+// Version can be overridden at build time using -ldflags "-X main.Version=x.y.z"
+var Version = "dev"
 
 type PasswordConfig struct {
 	Length         int


### PR DESCRIPTION
- Update Makefile to use dynamic versioning: VERSION?=$(shell git describe --tags --always --dirty)
- Change main.go Version from const to var for build-time injection
- Add version target to Makefile to display current version
- Update GitHub Actions release workflow to pass version to make commands
- Fix issue where release assets were named with hardcoded version
- Now binary version and release archives will match the Git tag
- Fallback to 'dev' version when no Git tags are present
- Support manual version override: VERSION=v1.0.1 make build

This resolves the version mismatch issue where v1.0.1 releases still showed v1.0.0 in asset names and binary version.