### PR TITLE
fix: Update default version to v1.0.1 for go install users

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ const (
 )
 
 // Version can be overridden at build time using -ldflags "-X main.Version=x.y.z"
-var Version = "dev"
+var Version = "v1.0.1"
 
 type PasswordConfig struct {
 	Length         int


### PR DESCRIPTION
- Change default Version from 'dev' to 'v1.0.1'
- Ensures users who install via 'go install' get the correct version
- Makefile dynamic version injection still works for releases
- Fixes issue where 'go install' users saw 'dev' instead of proper version

This resolves the version mismatch for go install users while maintaining dynamic version injection for release builds.